### PR TITLE
Fix for incorrect detection of Opera Mobile on Android

### DIFF
--- a/devicedetect.vcl
+++ b/devicedetect.vcl
@@ -1,8 +1,7 @@
-#
 # detectdevice.vcl - regex based device detection for Varnish
 # http://github.com/varnish/varnish-devicedetect/
 #
-# Author: Lasse Karstensen <lasse@varnish-software.com>
+# Author: Lasse Karstensen &lt;lasse@varnish-software.com&gt;
 
 sub devicedetect {
 	unset req.http.X-UA-Device;
@@ -29,6 +28,8 @@ sub devicedetect {
 		elsif (req.http.User-Agent ~ "(?i)android.*(mobile|mini)") { set req.http.X-UA-Device = "mobile-android"; }
 		// android 3/honeycomb was just about tablet-only, and any phones will probably handle a bigger page layout.
 		elsif (req.http.User-Agent ~ "(?i)android 3")              { set req.http.X-UA-Device = "tablet-android"; }
+		/* see http://my.opera.com/community/openweb/idopera/ */
+		elsif (req.http.User-Agent ~ "Opera Mobi") { set req.http.X-UA-Device = "mobile-smartphone"; }
 		// May very well give false positives towards android tablets. Suggestions welcome.
 		elsif (req.http.User-Agent ~ "(?i)android")         { set req.http.X-UA-Device = "tablet-android"; }
 		elsif (req.http.User-Agent ~ "Mobile.+Firefox")     { set req.http.X-UA-Device = "mobile-firefoxos"; }
@@ -36,8 +37,7 @@ sub devicedetect {
 		    req.http.User-Agent ~ "Fennec" ||
 		    req.http.User-Agent ~ "IEMobile" ||
 		    req.http.User-Agent ~ "BlackBerry" ||
-		    req.http.User-Agent ~ "SymbianOS.*AppleWebKit" ||
-		    req.http.User-Agent ~ "Opera Mobi") {
+		    req.http.User-Agent ~ "SymbianOS.*AppleWebKit") {
 			set req.http.X-UA-Device = "mobile-smartphone";
 		}
 		elsif (req.http.User-Agent ~ "(?i)symbian" ||


### PR DESCRIPTION
Opera Mobile on Android is incorrectly detected as Android Tablet.

An example user agent string is "Opera/9.80 (Android 4.1.2; Linux; Opera Mobi/ADR-1301080958) Presto/2.11.355 Version/12.10", which would result in successfully passing the "(?i)android" regex, before the "Opera Mobi" regex is checked.

To fix this, I've moved the "Opera Mobi" regex up to just before the check for Android Tablets.

As already mentioned in the comment, this was a false positive for Android Tablet.
