### PR TITLE
Improve 'Different backend for mobile clients' example.

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -187,6 +187,19 @@ special needs in VCL, you can use the X-UA-Device header like this::
             set req.backend = mobile;
         }
     }
+    
+    sub vcl_hash {
+        hash_data(req.url);
+        if (req.http.host) {
+            hash_data(req.http.host);
+        } else {
+            hash_data(server.ip);
+        }
+        if (req.http.X-UA-Device ~ "^mobile" || req.http.X-UA-device ~ "^tablet") {
+            hash_data("mobile");
+        }
+        return (hash);
+    }
 
 Redirecting mobile clients
 --------------------------


### PR DESCRIPTION
It's necesary overwrite de vcl_hash function for that varnish not caching the same for mobile and not mobile
