### PR TITLE
Added a warning concerning X-UA-Device

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -47,8 +47,9 @@ VCL::
                 set beresp.http.Vary = beresp.http.Vary + ", X-UA-Device"; 
             } 
         }
-        # comment this out if you don't want the client to know your classification
-        set beresp.http.X-UA-Device = req.http.X-UA-Device;
+        # remove comment for testing, be careful to use this in prod
+        # Google might be worried about crafted content
+        # set beresp.http.X-UA-Device = req.http.X-UA-Device;
     }
 
     # to keep any caches in the wild from serving wrong content to client #2 behind them, we need to


### PR DESCRIPTION
Commented the X-UA-Device, as we found out, that Google could interpret this wrong. Google marked our site as "hacked" without any real hack going on. We removed only that X-UA header, getting marked as clean again. It seems that Google is interpreting this as crafted content only for SEs (X-UA-Device:bot) as used by Viagra, Cialis SE hacks on servers (showing nothing to the browser, but spamming SE index with spam for bots)
