### PR TITLE
Add bot detection for Yahoo! Slurp spider

### DIFF
--- a/controlset.txt
+++ b/controlset.txt
@@ -12,6 +12,7 @@ bot	Wotbox/2.01 (+http://www.wotbox.com/bot/)
 bot	Mozilla/5.0 (compatible; AhrefsBot/3.1; +http://ahrefs.com/robot/)
 bot	Baiduspider+(+http://www.baidu.com/search/spider.htm)
 bot	Mozilla/5.0 (compatible; SeznamBot/3.2; +http://fulltext.sblog.cz/)
+bot	Mozilla/5.0 (compatible; Yahoo! Slurp; http://help.yahoo.com/help/us/ysearch/slurp)
 
 # from https://developers.google.com/webmasters/mobile-sites/references/googlebot
 mobile-bot	DoCoMo/2.0 N905i(c100;TB;W24H16) (compatible; Googlebot-Mobile/2.1; +http://www.google.com/bot.html)

--- a/devicedetect.vcl
+++ b/devicedetect.vcl
@@ -46,6 +46,7 @@ sub devicedetect {
 		elsif (req.http.User-Agent ~ "(?i)(ads|google|bing|msn|yandex|baidu|ro|career|seznam|)bot" ||
 		    req.http.User-Agent ~ "(?i)(baidu|jike|symantec)spider" ||
 		    req.http.User-Agent ~ "(?i)scanner" ||
+		    req.http.User-Agent ~ "(?i)slurp" ||
 		    req.http.User-Agent ~ "(?i)(web)crawler") {
 			set req.http.X-UA-Device = "bot"; }
 		elsif (req.http.User-Agent ~ "(?i)ipad")        { set req.http.X-UA-Device = "tablet-ipad"; }


### PR DESCRIPTION
The Yahoo spider user agent is `Mozilla/5.0 (compatible; Yahoo! Slurp; http://help.yahoo.com/help/us/ysearch/slurp)` and is not currently being detected as a bot by `devicedetect`.

See https://help.yahoo.com/kb/SLN22600.html for details.

I added a test case to `controlset.txt` and tests are passing locally for me but it appears that Travis is having issues here.